### PR TITLE
drop Python support below 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Windows has no dependencies. The Win32 extensions do not need to be installed.
 
 macOS needs the pyobjc-core and pyobjc module installed (in that order).
 
-Linux needs the python3-xlib (or python-xlib for Python 2) module installed.
+Linux needs the python3-xlib module installed.
 
 Pillow needs to be installed, and on Linux you may need to install additional libraries to make sure Pillow's PNG/JPEG works correctly. See:
 

--- a/pyautogui/__init__.py
+++ b/pyautogui/__init__.py
@@ -55,12 +55,7 @@ class ImageNotFoundException(PyAutoGUIException):
     """
 
 
-if sys.version_info[0] == 2 or sys.version_info[0:2] in ((3, 1), (3, 2)):
-    # Python 2 and 3.1 and 3.2 uses collections.Sequence
-    from collections import Sequence
-else:
-    # Python 3.3+ uses collections.abc.Sequence
-    from collections.abc import Sequence
+from collections.abc import Sequence
 
 
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pyautogui-next"
 authors = [{ name = "Al Sweigart", email = "al@inventwithpython.com" }]
 dynamic = ["version"]
-description = "PyAutoGUI lets Python control the mouse and keyboard, and other GUI automation tasks. For Windows, macOS, and Linux, on Python 3 and 2."
+description = "PyAutoGUI lets Python control the mouse and keyboard, and other GUI automation tasks on Windows, macOS, and Linux."
 readme = { file = "README.md", content-type = "text/markdown" }
 license = "BSD-3-Clause"
 keywords = ["gui", "automation", "test", "testing", "keyboard", "mouse", "cursor", "click", "press", "keystroke", "control"]
@@ -19,14 +19,15 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
+requires-python = ">=3.9"
 dependencies = [
     'pyobjc-core; platform_system == "Darwin"',
     'pyobjc-framework-quartz; platform_system == "Darwin"',
-    'python3-Xlib; platform_system == "Linux" and python_version >= "3.0"',
-    'python-xlib; platform_system == "Linux" and python_version < "3.0"',
+    'python3-Xlib; platform_system == "Linux"',
     'pymsgbox',
     'pytweening>=1.0.4',
     'pyscreeze>=0.1.21',

--- a/tests/test_pyautogui.py
+++ b/tests/test_pyautogui.py
@@ -7,7 +7,7 @@ import threading
 import time
 import unittest
 import doctest
-from collections import namedtuple  # Added in Python 2.6.
+from collections import namedtuple
 
 import pyautogui
 
@@ -15,7 +15,6 @@ import pyautogui
 scriptFolder = os.path.dirname(os.path.realpath(__file__))
 os.chdir(scriptFolder)
 
-runningOnPython2 = sys.version_info[0] == 2
 
 if runningOnPython2:
     INPUT_FUNC = raw_input

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py31, py32, py33, py34, py35, py36, py37
+envlist = py39, py310, py311
 
 [testenv]
 deps =


### PR DESCRIPTION
Implements the first sweep for dropping support for Python versions older than 3.9.

Summary:
- remove pre-3.3 `collections.Sequence` compatibility branch
- set `requires-python` to `>=3.9`
- add Python 3.9 classifier
- remove Python 2 dependency branch for Xlib in packaging metadata
- update tox env list to `py39`, `py310`, `py311`
- remove leftover Python 2 test variable/comments in tests
- update README dependency wording to remove Python 2 Xlib reference

Notes:
- build passes after the change
- there are still additional old-version references in docs/history files that can be cleaned up in follow-up work if wanted