### PR TITLE
use python-xlib dependency name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.9"
 dependencies = [
     'pyobjc-core; platform_system == "Darwin"',
     'pyobjc-framework-quartz; platform_system == "Darwin"',
-    'python-Xlib; platform_system == "Linux"',
+    'python-Xlib>=0.16; platform_system == "Linux"',
     'pymsgbox',
     'pytweening>=1.0.4',
     'pyscreeze>=0.1.21',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.9"
 dependencies = [
     'pyobjc-core; platform_system == "Darwin"',
     'pyobjc-framework-quartz; platform_system == "Darwin"',
-    'python3-Xlib; platform_system == "Linux"',
+    'python-Xlib; platform_system == "Linux"',
     'pymsgbox',
     'pytweening>=1.0.4',
     'pyscreeze>=0.1.21',


### PR DESCRIPTION
## Summary
- change the Linux Xlib dependency from `python3-Xlib` to `python-Xlib`
- keep the Linux platform marker in place

## Upstream context
- based on upstream PR #503: https://github.com/asweigart/pyautogui/pull/503

## Notes
- current `main` test branch state is unchanged by this PR
- this PR is intentionally scoped to the dependency name only