### PR TITLE
Add optional [x11] extra for remote X11 on macOS/Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ macOS needs the pyobjc-core and pyobjc module installed (in that order).
 
 Linux needs the python3-xlib module installed.
 
+For non-Linux hosts that need remote X11 (TCP) connections, install the optional extra:
+
+`pip install "pyautogui-next[x11]"`
+
 Pillow needs to be installed, and on Linux you may need to install additional libraries to make sure Pillow's PNG/JPEG works correctly. See:
 
     https://stackoverflow.com/questions/7648200/pip-install-pil-e-tickets-1-no-jpeg-png-support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ dependencies = [
     'mouseinfo',
 ]
 
+[project.optional-dependencies]
+x11 = [
+    'python-Xlib>=0.16',
+]
+
 [dependency-groups]
 dev = [
     "pillow",


### PR DESCRIPTION
## Summary
- keep python-Xlib as a Linux runtime dependency
- add optional x11 extra so non-Linux hosts can install Xlib when needed
- document explicit install command in README

## Note
For remote x11 connections in windows/macos, install with [x11].
